### PR TITLE
Make looptask stack size configurable

### DIFF
--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -3,6 +3,10 @@
 #include "esp_task_wdt.h"
 #include "Arduino.h"
 
+#ifndef LOOP_STACK_SIZE
+#define LOOP_STACK_SIZE 8192
+#endif
+
 TaskHandle_t loopTaskHandle = NULL;
 
 #if CONFIG_AUTOSTART_ARDUINO
@@ -25,7 +29,7 @@ extern "C" void app_main()
 {
     loopTaskWDTEnabled = false;
     initArduino();
-    xTaskCreateUniversal(loopTask, "loopTask", 8192, NULL, 1, &loopTaskHandle, CONFIG_ARDUINO_RUNNING_CORE);
+    xTaskCreateUniversal(loopTask, "loopTask", LOOP_STACK_SIZE, NULL, 1, &loopTaskHandle, CONFIG_ARDUINO_RUNNING_CORE);
 }
 
 #endif

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -3,8 +3,8 @@
 #include "esp_task_wdt.h"
 #include "Arduino.h"
 
-#ifndef LOOP_STACK_SIZE
-#define LOOP_STACK_SIZE 8192
+#ifndef CONFIG_ARDUINO_LOOP_STACK_SIZE
+#define CONFIG_ARDUINO_LOOP_STACK_SIZE 8192
 #endif
 
 TaskHandle_t loopTaskHandle = NULL;
@@ -29,7 +29,7 @@ extern "C" void app_main()
 {
     loopTaskWDTEnabled = false;
     initArduino();
-    xTaskCreateUniversal(loopTask, "loopTask", LOOP_STACK_SIZE, NULL, 1, &loopTaskHandle, CONFIG_ARDUINO_RUNNING_CORE);
+    xTaskCreateUniversal(loopTask, "loopTask", CONFIG_ARDUINO_LOOP_STACK_SIZE, NULL, 1, &loopTaskHandle, CONFIG_ARDUINO_RUNNING_CORE);
 }
 
 #endif


### PR DESCRIPTION
Added guarded define to set the stacksize on the main looptask.
Advantage of this is that build_flags can be used to provide a different value for the stack size should it be neccessary
default behaviour is unaffected